### PR TITLE
Remove protobuf python package from what we're installing

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -74,7 +74,7 @@ __grpc_install_with_brew() {
     # We need version of protobuf that already has C# and objectiveC support, which haven't been released yet,
     # so we just install HEAD for now.
     # TODO(jtattermusch): Ideally, we should depend on the revision of protobufs we refer to in third_party/protobuf.
-    __grpc_brew_install --HEAD google-protobuf
+    __grpc_brew_install --HEAD --without-python google-protobuf
 
     # Install gRPC
     __grpc_brew_install --HEAD grpc


### PR DESCRIPTION
It was problematic on Linux
