### PR TITLE
Update homebrew formulas to gRPC 0.11.0

### DIFF
--- a/Formula/google-protobuf.rb
+++ b/Formula/google-protobuf.rb
@@ -3,9 +3,9 @@
 class GoogleProtobuf < Formula
   homepage "https://github.com/google/protobuf/"
   head "https://github.com/google/protobuf.git"
-  url 'https://github.com/google/protobuf/archive/v3.0.0-alpha-3.tar.gz'
-  version "3.0.0-alpha-3"
-  sha256 'bf90fb01b054d364d05d362d63e09d3466311e24bd6db1127dfcd88af443bf05'
+  url 'https://github.com/google/protobuf/archive/v3.0.0-beta-1.tar.gz'
+  version "3.0.0-beta-1"
+  sha256 '8590587749a9d969b277ad050f710a3dfa7816e7e44f34c953dd3730ca550850'
 
   depends_on "m4" => :build
   depends_on "autoconf" => :build

--- a/Formula/google-protobuf.rb
+++ b/Formula/google-protobuf.rb
@@ -7,7 +7,6 @@ class GoogleProtobuf < Formula
   version "3.0.0-beta-1"
   sha256 '8590587749a9d969b277ad050f710a3dfa7816e7e44f34c953dd3730ca550850'
 
-  depends_on "m4" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/google-protobuf.rb
+++ b/Formula/google-protobuf.rb
@@ -7,6 +7,13 @@ class GoogleProtobuf < Formula
   version "3.0.0-beta-1"
   sha256 '8590587749a9d969b277ad050f710a3dfa7816e7e44f34c953dd3730ca550850'
 
+  # Fix assignment syntax error in python extension.
+  # See https://github.com/google/protobuf/pull/776
+  patch do
+    url "https://raw.githubusercontent.com/grpc/homebrew-grpc/master/patches/google_protobuf_4472b4a_Fixed-assignment-syntax-error.patch"
+    sha256 "47cbaaf7e782b09edb5dcf10ff6b7892af8f506df4d82f71877957de3552afa4"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -1,8 +1,8 @@
 class Grpc < Formula
   desc "gRPC is the next generation open source RPC library and framework"
   homepage "http://www.grpc.io/"
-  url "https://github.com/grpc/grpc/archive/release-0_10_0.tar.gz"
-  sha256 "c4fbada4990ca5e322075c17ce66a311460e67c290d61796df67abd058fca8e1"
+  url "https://github.com/grpc/grpc/archive/release-0_11_0.tar.gz"
+  sha256 "2d54b207733c5a48d6ce8f62d3a50541d73cd13b3af7df35396ee137d21a12d7"
   head "https://github.com/grpc/grpc.git"
 
   bottle do


### PR DESCRIPTION
-- bump grpc version
-- bump protobuf version
-- remove dependency on m4 (seems like it was removed from homebrew entirely).
