### PR TITLE
Enable installing just protoc plugins on Linux

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -15,8 +15,15 @@ class Grpc < Formula
   depends_on "pkg-config" => :build
   depends_on "google-protobuf"
 
+  option "without-libgrpc", "Do now install gRPC C core library, only install gRPC protoc plugins."
+
   def install
-    system "make", "install", "install_grpc_csharp_ext", "prefix=#{prefix}"
+    unless build.without? "libgrpc"
+      system "make", "install", "install_grpc_csharp_ext", "prefix=#{prefix}"
+    else
+      system "make", "install-plugins", "prefix=#{prefix}"
+    end
+
     # Link the Objective-C plugin to the name protoc expects.
     # TODO: Do this renaming on make install, for all languages.
     bin.install_symlink bin/"grpc_objective_c_plugin" => "protoc-gen-objcgrpc"

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -15,7 +15,7 @@ class Grpc < Formula
   depends_on "pkg-config" => :build
   depends_on "google-protobuf"
 
-  option "without-libgrpc", "Do now install gRPC C core library, only install gRPC protoc plugins."
+  option "without-libgrpc", "Do not install gRPC C core library, only install gRPC protoc plugins."
 
   def install
     unless build.without? "libgrpc"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quick Install: Linux
 
 _UPDATE (9/30/2015): Linuxbrew is no longer the official way to install gRPC
 on Linux platform. You should use official Debian packages from [jessie-backports][]
-to install `libgrpc`. Nevertheless, the Debian packages for the latest version
+to install `libgrpc-dev`. Nevertheless, the Debian packages for the latest version
 of [protobuf][] and gRPC protoc plugins (needed to generate code for gRPC service stubs) are still work in progress and the easiest way to install them is using Linuxbrew._
 
 The repo contains an [install script][] that can be used to install gRPC protoc plugins.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,34 @@ Prerequisites
 - On Mac OS X, install [homebrew][].
 - On Linux, install [linuxbrew][].
 
-Quick Install
--------------
+Quick Install: Linux
+--------------------
+
+_UPDATE (9/30/2015): Linuxbrew is no longer the official way to install gRPC
+on Linux platform. You should use official Debian packages from [jessie-backports][]
+to install `libgrpc`. Nevertheless, the Debian packages for the latest version
+of [protobuf][] and gRPC protoc plugins (needed to generate code for gRPC service stubs) are still work in progress and the easiest way to install them is using Linuxbrew._
+
+The repo contains an [install script][] that can be used to install gRPC protoc plugins.
+For convenience, the installer is also available at a short alias
+https://goo.gl/getgrpc
+
+- To install the gRPC protoc plugins for C++, C#, ObjectiveC, Python and Ruby
+```sh
+$ curl -fsSL https://goo.gl/getgrpc | bash -s plugins
+```
+
+- Alternatively, you can use gRPC formula directly
+```sh
+brew tap grpc/grpc
+brew install --without-libgrpc grpc
+```
+
+Quick Install: Mac OS X
+-----------------------
+
+_UPDATE (9/30/2015): Homebrew continues to be the official way how to install
+gRPC on Mac OS X._
 
 The repo contains an [install script][] that can be used to install gRPC and
 optionally install the gRPC package for Python, Node.Js and/or Ruby as long as
@@ -84,6 +110,8 @@ Docs
 [wiki]:http://wiki.github.com/Homebrew/homebrew
 [homebrew]:http://brew.sh
 [linuxbrew]:https://github.com/Homebrew/linuxbrew
+[jessie-backports]:http://backports.debian.org/Instructions/
+[protobuf]:https://github.com/google/protobuf/releases
 [install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
 [nvm]: https://github.com/creationix/nvm

--- a/scripts/install
+++ b/scripts/install
@@ -11,6 +11,9 @@
 # Install grpc core:
 #   curl -fsSL https://goo.gl/getgrpc | bash -
 #
+# Install grpc protoc plugins only:
+#   curl -fsSL https://goo.gl/getgrpc | bash -s plugins
+#
 # Install grpc ruby:
 #   curl -fsSL https://goo.gl/getgrpc | bash -s ruby
 #
@@ -87,7 +90,7 @@ __grpc_install_with_brew() {
     __grpc_brew_install --without-python google-protobuf
 
     # Install gRPC
-    __grpc_brew_install grpc
+    __grpc_brew_install "$@" grpc
 }
 
 __grpc_install_ruby_pkg() {
@@ -169,8 +172,20 @@ __grpc_install_pkgs() {
 
 main() {
     __grpc_check_for_brew;
-    __grpc_install_with_brew;
-    __grpc_install_pkgs "$@";
+
+    local install_with_brew_args=""
+    local install_pkgs_args=""
+    for arg in "$@"; do
+      if [ "$arg" == "plugins" ]
+      then
+        install_with_brew_args+="--without-libgrpc "
+      else
+        install_pkgs_args+="$arg "
+      fi
+    done
+
+    __grpc_install_with_brew "$install_with_brew_args";
+    __grpc_install_pkgs "$install_pkgs_args";
 }
 
 main "$@"


### PR DESCRIPTION
-- only use linuxbrew to install protoc plugins on Linux
-- update docs to clearly warn that this is just temporary
