### PR TITLE
Update install scripts GRPC to match latest version

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -22,7 +22,7 @@
 
 set -e
 
-GRPC_VERSION='0.11.0'
+GRPC_VERSION='0.12.0'
 
 __grpc_check_for_brew() {
     which 'brew' >> /dev/null || {


### PR DESCRIPTION
Otherwise, if you try to use the install script with grpc 0.11.0 installed, you'll simply get it return 0 and no  clear indication of why it didn't install the latest. 
