### PR TITLE
Remove fails_with as it's depreciated

### DIFF
--- a/Formula/google-protobuf.rb
+++ b/Formula/google-protobuf.rb
@@ -22,9 +22,9 @@ class GoogleProtobuf < Formula
   option "without-python", "Build without python support"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
 
-  fails_with :llvm do
-    build 2334
-  end
+#   fails_with :llvm do
+#     build 2334
+#   end
 
   resource "setuptools" do
     url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.7.1.tar.gz"


### PR DESCRIPTION
`fails_with` is depreciated and causing install warnings:

    Warning: Calling fails_with :llvm is deprecated!
    There is no replacement.
    /usr/local/Homebrew/Library/Taps/grpc/homebrew-grpc/Formula/google-protobuf.rb:25:in `<class:GoogleProtobuf>'
    Please report this to the grpc/grpc tap!

